### PR TITLE
Fix reference

### DIFF
--- a/docs/lit/using-concourse/resource-types.lit
+++ b/docs/lit/using-concourse/resource-types.lit
@@ -216,7 +216,7 @@ before using it!
     Fork the
     \link{\code{concourse/concourse}}{https://github.com/concourse/concourse}
     repository, edit
-    \code{concourse/docs/using-concourse/resource-types.any},
+    \code{concourse/docs/lit/using-concourse/resource-types.lit},
     then make a pull request.
   }
 }


### PR DESCRIPTION
Fix reference to point to `concourse/docs/lit/using-concourse/resource-types.lit` instead of `concourse/docs/using-concourse/resource-types.any`